### PR TITLE
Log into codeartifact before touching conda/mamba

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,6 +37,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
 
+      - name: Log in to AWS CodeArtifact
+        run: |
+          aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
+          --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
+
       # Configure conda
       - name: Set up micromamba
         uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
@@ -54,11 +59,6 @@ jobs:
           restore-keys: |
             pip-${{ hashFiles('setup.cfg') }}
             pip-
-
-      - name: Log in to AWS CodeArtifact
-        run: |
-          aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
-          --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
       - name: Install package
         run: python -m pip install .[tests]

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -66,12 +66,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
 
-      # Setup SSH keys to clone private repos
-      - name: Set up SSH agent
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: |
-            ${{ secrets.MLUTILS_DEPLOY_KEY }}
+      - name: Log in to AWS CodeArtifact
+        run: |
+          aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
+          --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
       # Configure conda
       - name: Set up micromamba
@@ -92,11 +90,6 @@ jobs:
           restore-keys: |
             pip-${{ hashFiles('setup.cfg') }}
             pip-
-
-      - name: Log in to AWS CodeArtifact
-        run: |
-          aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
-          --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
       - name: Extra Index URLs
         run: export EXTRA_INDEX_URL=${{ inputs.extra_index_url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,18 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
+
+    - name: Log in to AWS CodeArtifact
+      run: |
+        aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
+        --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
+
     # Configure conda
     - name: Set up micromamba
       uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
@@ -60,18 +72,6 @@ jobs:
         restore-keys: |
           pip-${{ hashFiles('setup.cfg') }}
           pip-
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-central-1
-
-    - name: Log in to AWS CodeArtifact
-      run: |
-        aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
-        --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
     - name: Install package
       run: |


### PR DESCRIPTION
If the `environment.yml` includes a `pip install` step, we need to have already logged into CodeArtifact.