### PR TITLE
feature: add apt-get packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,18 +49,6 @@ jobs:
     - name: Install apt packages
       run: sudo apt-get install --yes ${{ inputs.apt_packages }}
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-central-1
-
-    - name: Log in to AWS CodeArtifact
-      run: |
-        aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
-        --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
-
     # Configure conda
     - name: Set up micromamba
       uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
@@ -80,6 +68,18 @@ jobs:
         restore-keys: |
           pip-${{ hashFiles('setup.cfg') }}
           pip-
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
+
+    - name: Log in to AWS CodeArtifact
+      run: |
+        aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
+        --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
     - name: Install package
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: '["3.9"]'
+      apt_packages:
+        description: string containing apt package names
+        required: false
+        type: string
+        default: ''        
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -41,6 +46,21 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install apt packages
+      run: sudo apt-get install --yes ${{ inputs.apt_packages }}
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
+
+    - name: Log in to AWS CodeArtifact
+      run: |
+        aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
+        --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
+
     # Configure conda
     - name: Set up micromamba
       uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
@@ -60,18 +80,6 @@ jobs:
         restore-keys: |
           pip-${{ hashFiles('setup.cfg') }}
           pip-
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-central-1
-
-    - name: Log in to AWS CodeArtifact
-      run: |
-        aws codeartifact login --tool pip --repository charm-pypi --domain charm-pypi \
-        --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
     - name: Install package
       run: |


### PR DESCRIPTION
Working on another PR I found it necessary to

- move the aws codeartefact login block higher up, so that it can be picked-up by conda environment.yml using private pypi packagse
- install custom apt-get packages that were required to install certain conda deps

I tested this on my happy PR here https://github.com/CHARM-Tx/ray-fep-cluster/pull/12