### PR TITLE
Monorepo support

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,11 @@ on:
         type: string
         description: the name of the source code module to document
         required: true
+      path:
+        type: string
+        description: Path of package, relative to the repo root
+        required: false
+        default: '.'
 
 jobs:
   generate-docs:
@@ -64,9 +69,11 @@ jobs:
         run: python -m pip install .[tests]
 
       - name: Generate documentation
+        working-directory: ${{ inputs.path }}
         run: python -m pdoc ${{ inputs.module_name }} --docformat google --output-directory html_docs
 
       - name: Upload to s3 (dry run)
+        working-directory: ${{ inputs.path }}
         run: |
           VERSION=${{ github.ref_name }}
           echo "Version: $VERSION"
@@ -74,6 +81,7 @@ jobs:
           aws s3 sync --dryrun html_docs/ s3://charmtx-python-doc/${{inputs.module_name}}/latest/
 
       - name: Upload to s3
+        working-directory: ${{ inputs.path }}
         run: |
           VERSION=${{ github.ref_name }}
           echo "Version: $VERSION"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -66,6 +66,7 @@ jobs:
           --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
       - name: Install package
+        working-directory: ${{ inputs.path }}
         run: python -m pip install .[tests]
 
       - name: Generate documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           cache-downloads: true
           cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
-          environment-file: ${{ inputs.path }}/${{ inputs.environment_file }}
+          environment-file: ./${{ inputs.path }}/${{ inputs.environment_file }}
           environment-name: document
 
       - name: Cache pip downloads
@@ -66,15 +66,15 @@ jobs:
           --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
       - name: Install package
-        working-directory: ${{ inputs.path }}
+        working-directory: ./${{ inputs.path }}
         run: python -m pip install .[tests]
 
       - name: Generate documentation
-        working-directory: ${{ inputs.path }}
+        working-directory: ./${{ inputs.path }}
         run: python -m pdoc ${{ inputs.module_name }} --docformat google --output-directory html_docs
 
       - name: Upload to s3 (dry run)
-        working-directory: ${{ inputs.path }}
+        working-directory: ./${{ inputs.path }}
         run: |
           VERSION=${{ github.ref_name }}
           echo "Version: $VERSION"
@@ -82,7 +82,7 @@ jobs:
           aws s3 sync --dryrun html_docs/ s3://charmtx-python-doc/${{inputs.module_name}}/latest/
 
       - name: Upload to s3
-        working-directory: ${{ inputs.path }}
+        working-directory: ./${{ inputs.path }}
         run: |
           VERSION=${{ github.ref_name }}
           echo "Version: $VERSION"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           cache-downloads: true
           cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
-          environment-file: ${{ inputs.environment_file }}
+          environment-file: ${{ inputs.path }}/${{ inputs.environment_file }}
           environment-name: document
 
       - name: Cache pip downloads

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,4 @@ jobs:
         working-directory: ./${{ inputs.path }}
         run: |
           pip install flake8 ${{ inputs.flake8_plugins }}
-          python -m flake8
+          python -m flake8 .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,11 @@ on:
         type: string
         description: space-delimited list of flake8 plugins to install
         required: false
+      path:
+        type: string
+        description: Path of package, relative to the repo root
+        required: false
+        default: '.'
 
 jobs:
   python-lint:
@@ -19,12 +24,13 @@ jobs:
           python-version: '3.9'
       - uses: psf/black@22.1.0
         with:
-          src: "."
+          src: ${{ inputs.path }}
       - uses: isort/isort-action@master
         with:
-          sortPaths: "."
+          sortPaths: ${{ inputs.path }}
           isortVersion: "5.10.1"
       - name: Run flake8
+        working-directory: ${{ inputs.path }}
         run: |
           pip install flake8 ${{ inputs.flake8_plugins }}
-          python -m flake8 .
+          python -m flake8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,13 +24,13 @@ jobs:
           python-version: '3.9'
       - uses: psf/black@22.1.0
         with:
-          src: ${{ inputs.path }}
+          src: ./${{ inputs.path }}
       - uses: isort/isort-action@master
         with:
-          sortPaths: ${{ inputs.path }}
+          sortPaths: ./${{ inputs.path }}
           isortVersion: "5.10.1"
       - name: Run flake8
-        working-directory: ${{ inputs.path }}
+        working-directory: ./${{ inputs.path }}
         run: |
           pip install flake8 ${{ inputs.flake8_plugins }}
           python -m flake8

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           cache-downloads: true
           cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
-          environment-file: ${{ inputs.environment_file }}
+          environment-file: ${{ inputs.path }}/${{ inputs.environment_file }}
           environment-name: typecheck
           extra-specs: |
             python=${{ matrix.python-version }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           cache-downloads: true
           cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
-          environment-file: ${{ inputs.path }}/${{ inputs.environment_file }}
+          environment-file: ./${{ inputs.path }}/${{ inputs.environment_file }}
           environment-name: typecheck
           extra-specs: |
             python=${{ matrix.python-version }}
@@ -112,20 +112,20 @@ jobs:
         run: export EXTRA_INDEX_URL=${{ inputs.extra_index_url }}
 
       - name: Install package
-        working-directory: ${{ inputs.path }}
+        working-directory: ./${{ inputs.path }}
         run: python -m pip install ${{ inputs.pip_install_args }} .[tests]
         if: ${{ !inputs.requirements_file }}
 
       - name: Install from requirements file
-        working-directory: ${{ inputs.path }}
+        working-directory: ./${{ inputs.path }}
         run: python -m pip install --no-deps ${{ inputs.pip_install_args }} -r ${{ inputs.requirements_file }}
         if: ${{ inputs.requirements_file }}
 
       - name: Mypy Type Install
-        working-directory: ${{ inputs.path }}
+        working-directory: ./${{ inputs.path }}
         run: python -m mypy --install-types --non-interactive
         if: ${{ inputs.install_types }}
 
       - name: Mypy
-        working-directory: ${{ inputs.path }}
+        working-directory: ./${{ inputs.path }}
         run: python -m mypy

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: string
         default: ''
+      path:
+        type: string
+        description: Path of package, relative to the repo root
+        required: false
+        default: '.'
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -107,16 +112,20 @@ jobs:
         run: export EXTRA_INDEX_URL=${{ inputs.extra_index_url }}
 
       - name: Install package
+        working-directory: ${{ inputs.path }}
         run: python -m pip install ${{ inputs.pip_install_args }} .[tests]
         if: ${{ !inputs.requirements_file }}
 
       - name: Install from requirements file
+        working-directory: ${{ inputs.path }}
         run: python -m pip install --no-deps ${{ inputs.pip_install_args }} -r ${{ inputs.requirements_file }}
         if: ${{ inputs.requirements_file }}
 
       - name: Mypy Type Install
+        working-directory: ${{ inputs.path }}
         run: python -m mypy --install-types --non-interactive
         if: ${{ inputs.install_types }}
 
       - name: Mypy
+        working-directory: ${{ inputs.path }}
         run: python -m mypy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,11 @@ jobs:
         --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
     - name: Build
-      working-directory: ${{ inputs.path }}
+      working-directory: ./${{ inputs.path }}
       run: python -m build
 
 # We only run a publish if this CI is running after a tag/release.
     - name: Publish
-      working-directory: ${{ inputs.path }}
+      working-directory: ./${{ inputs.path }}
       if: startsWith(github.ref, 'refs/tags/v')
       run: twine upload --repository codeartifact dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ name: Upload Python Package
 
 on:
   workflow_call:
+    inputs:
+      path:
+        type: string
+        description: Path of package, relative to the repo root
+        required: false
+        default: '.'
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -44,9 +50,11 @@ jobs:
         --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
     - name: Build
+      working-directory: ${{ inputs.path }}
       run: python -m build
 
 # We only run a publish if this CI is running after a tag/release.
     - name: Publish
+      working-directory: ${{ inputs.path }}
       if: startsWith(github.ref, 'refs/tags/v')
       run: twine upload --repository codeartifact dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Code Coverage
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        filename: ${{inputs.path}/coverage.xml
+        filename: ${{ inputs.path }}/coverage.xml
         badge: true
         format: markdown
         hide_branch_rate: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: ''
+      path:
+        type: string
+        description: Path of package, relative to the repo root
+        required: false
+        default: '.'
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -87,17 +92,19 @@ jobs:
         --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
     - name: Install package
+      working-directory: ${{ inputs.path }}
       run: |
         python -m pip install ${{ inputs.pip_install_args }} .[tests]
 
     - name: Test with pytest
+      working-directory: ${{ inputs.path }}
       run: |
         python -m pytest --cov-report=xml
 
     - name: Code Coverage
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        filename: coverage.xml
+        filename: ${{inputs.path}/coverage.xml
         badge: true
         format: markdown
         hide_branch_rate: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         cache-downloads: true
         cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
-        environment-file: ${{ inputs.path }}/${{ inputs.environment_file }}
+        environment-file: ./${{ inputs.path }}/${{ inputs.environment_file }}
         environment-name: unit-testing
         extra-specs:
           python=${{ matrix.python-version }}
@@ -92,19 +92,19 @@ jobs:
         --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
 
     - name: Install package
-      working-directory: ${{ inputs.path }}
+      working-directory: ./${{ inputs.path }}
       run: |
         python -m pip install ${{ inputs.pip_install_args }} .[tests]
 
     - name: Test with pytest
-      working-directory: ${{ inputs.path }}
+      working-directory: ./${{ inputs.path }}
       run: |
         python -m pytest --cov-report=xml
 
     - name: Code Coverage
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        filename: ${{ inputs.path }}/coverage.xml
+        filename: ./${{ inputs.path }}/coverage.xml
         badge: true
         format: markdown
         hide_branch_rate: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         cache-downloads: true
         cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
-        environment-file: ${{ inputs.environment_file }}
+        environment-file: ${{ inputs.path }}/${{ inputs.environment_file }}
         environment-name: unit-testing
         extra-specs:
           python=${{ matrix.python-version }}


### PR DESCRIPTION
This modifies the various workflows to support a `path` to indicate where a package is relative to the repository root. This enables support for repositories containing more than one python package.

This is tested by the fact that https://github.com/CHARM-Tx/chemutils/pull/81 works, with three repos being tested, linted, documented and released