### PR TITLE
Allow no `environment.yml`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Configure conda
       - name: Set up micromamba
-        if: ${{ inputs.environment_file }}
+        if: ${{ inputs.environment_file != '' }}
         uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
         with:
           cache-downloads: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,6 +44,7 @@ jobs:
 
       # Configure conda
       - name: Set up micromamba
+        if: ${{ inputs.environment_file }}
         uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
         with:
           cache-downloads: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,6 +17,11 @@ on:
         description: Path of package, relative to the repo root
         required: false
         default: '.'
+      python_version:
+        description: Version of python to use if an environment file is not provided
+        required: false
+        type: string
+        default: '3.9'
 
 jobs:
   generate-docs:
@@ -51,6 +56,18 @@ jobs:
           cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
           environment-file: ./${{ inputs.path }}/${{ inputs.environment_file }}
           environment-name: document
+
+      # Configure conda
+      - name: Set up micromamba
+        if: ${{ inputs.environment_file == '' }}
+        uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
+        with:
+          cache-downloads: true
+          cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
+          environment-file: false
+          environment-name: document
+          extra-specs: |
+            python=${{ inputs.python_version }}
 
       - name: Cache pip downloads
         uses: actions/cache@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -63,7 +63,7 @@ jobs:
         uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
         with:
           cache-downloads: true
-          cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
+          cache-downloads-key: "mamba-noenv"
           environment-file: false
           environment-name: document
           extra-specs: |

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -83,7 +83,7 @@ jobs:
           ssh-private-key: |
             ${{ secrets.MLUTILS_DEPLOY_KEY }}
 
-      # Configure conda
+      # Configure conda if an environment file is provided
       - name: Set up micromamba
         if: ${{ inputs.environment_file != '' }}
         uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
@@ -91,6 +91,18 @@ jobs:
           cache-downloads: true
           cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
           environment-file: ./${{ inputs.path }}/${{ inputs.environment_file }}
+          environment-name: typecheck
+          extra-specs: |
+            python=${{ matrix.python-version }}
+
+      # Configure conda if an environment file is not provided
+      - name: Set up micromamba
+        if: ${{ inputs.environment_file == '' }}
+        uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
+        with:
+          cache-downloads: true
+          cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
+          environment-file: false
           environment-name: typecheck
           extra-specs: |
             python=${{ matrix.python-version }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -85,7 +85,7 @@ jobs:
 
       # Configure conda
       - name: Set up micromamba
-        if: ${{ inputs.environment_file }}
+        if: ${{ inputs.environment_file != '' }}
         uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
         with:
           cache-downloads: true

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -85,6 +85,7 @@ jobs:
 
       # Configure conda
       - name: Set up micromamba
+        if: ${{ inputs.environment_file }}
         uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
         with:
           cache-downloads: true

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -101,7 +101,7 @@ jobs:
         uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
         with:
           cache-downloads: true
-          cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
+          cache-downloads-key: "mamba-noenv"
           environment-file: false
           environment-name: typecheck
           extra-specs: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
 
     # Configure conda
     - name: Set up micromamba
-      if: ${{ inputs.environment_file }}
+      if: ${{ inputs.environment_file != '' }}
       uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
       with:
         cache-downloads: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install apt packages
       run: sudo apt-get install --yes ${{ inputs.apt_packages }}
 
-    # Configure conda
+    # Configure conda if an environment file is provided
     - name: Set up micromamba
       if: ${{ inputs.environment_file != '' }}
       uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
@@ -68,7 +68,19 @@ jobs:
         cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
         environment-file: ./${{ inputs.path }}/${{ inputs.environment_file }}
         environment-name: unit-testing
-        extra-specs:
+        extra-specs: |
+          python=${{ matrix.python-version }}
+
+    # Configure conda if an environment file is not provided
+    - name: Set up micromamba
+      if: ${{ inputs.environment_file == '' }}
+      uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
+      with:
+        cache-downloads: true
+        cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
+        environment-file: false
+        environment-name: unit-testing
+        extra-specs: |
           python=${{ matrix.python-version }}
 
     - name: Cache pip downloads

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
       uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
       with:
         cache-downloads: true
-        cache-downloads-key: "mamba-${{ hashFiles(inputs.environment_file) }}"
+        cache-downloads-key: "mamba-noenv"
         environment-file: false
         environment-name: unit-testing
         extra-specs: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
 
     # Configure conda
     - name: Set up micromamba
+      if: ${{ inputs.environment_file }}
       uses: mamba-org/provision-with-micromamba@5fe88d370c741fc3567126d17c5af0b9620bd60d
       with:
         cache-downloads: true


### PR DESCRIPTION
Not all projects should/need to use conda and an `environment.yml`, so allow it to be set to `''` (the default remains `environment.yml`)

https://github.com/CHARM-Tx/cbor-np/pull/1 is a working example showing this works