### PR TITLE
Coverage Artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,11 @@ jobs:
       run: |
         python -m pytest --cov-report=xml
 
+    - uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: ./${{ inputs.path }}/coverage.xml
+
     - name: Code Coverage
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
@@ -125,8 +130,3 @@ jobs:
         indicators: true
         output: both
         thresholds: '80 100'
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: coverage
-        path: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: coverage
-        path: ./${{ inputs.path }}/coverage.xml
+        path: coverage.xml
 
     - name: Code Coverage
       uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,12 +112,7 @@ jobs:
     - name: Test with pytest
       working-directory: ./${{ inputs.path }}
       run: |
-        python -m pytest
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: coverage
-        path: coverage.xml
+        python -m pytest --cov-report=xml
 
     - name: Code Coverage
       uses: irongut/CodeCoverageSummary@v1.3.0
@@ -130,3 +125,8 @@ jobs:
         indicators: true
         output: both
         thresholds: '80 100'
+    
+    - uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,3 +125,8 @@ jobs:
         indicators: true
         output: both
         thresholds: '80 100'
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Test with pytest
       working-directory: ./${{ inputs.path }}
       run: |
-        python -m pytest --cov-report=xml
+        python -m pytest
 
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Expose `coverage.xml` as an artifact, so subsequent jobs can do things like upload to codecov etc.